### PR TITLE
Add disconnect handler for when bot is inactive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ chrono = "0.4.23"
 chrono-tz = "0.8.1"
 serde = {version = "1.0.152", features = ["derive"]}
 serde_json = "1.0.91"
+once_cell = "1.17.1"
 
 [dependencies.songbird]
 version = "0.3.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,11 +10,7 @@ use serenity::{
     client::bridge::gateway::ShardManager,
     framework::{standard::macros::group, StandardFramework},
     http::Http,
-    model::{
-        event::ResumedEvent,
-        gateway::Ready,
-        guild::Member,
-    },
+    model::{event::ResumedEvent, gateway::Ready, guild::Member},
     prelude::*,
 };
 use songbird::SerenityInit;
@@ -69,7 +65,6 @@ impl EventHandler for Handler {
                 return;
             }
         };
-
     }
 }
 
@@ -80,7 +75,7 @@ struct General;
 
 #[group]
 #[prefix = "m"]
-#[commands(join, leave, play, pause, resume, search, skip, stop, info)]
+#[commands(join, leave, play, pause, resume, skip, stop, info)]
 struct Voice;
 
 #[tokio::main]

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ use songbird::SerenityInit;
 use tracing::{error, info};
 
 use crate::commands::{guild::*, math::*, quotes::*, wotd::*};
-use crate::voice::*;
+use crate::voice::cmds::*;
 
 pub struct ShardManagerContainer;
 

--- a/src/voice/cmds.rs
+++ b/src/voice/cmds.rs
@@ -458,3 +458,4 @@ fn song_embed(current_track: TrackHandle, postion: usize) -> CreateEmbed {
         .to_owned();
     embed
 }
+

--- a/src/voice/cmds.rs
+++ b/src/voice/cmds.rs
@@ -67,29 +67,10 @@ async fn leave(ctx: &Context, msg: &Message) -> CommandResult {
 
 #[command]
 #[only_in(guilds)]
-async fn play(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult {
-    let url = match args.single::<String>() {
-        Ok(url) => url,
-        Err(_) => {
-            check_msg(
-                msg.channel_id
-                    .say(&ctx.http, "Must provide a URL to a video or audio")
-                    .await,
-            );
-
-            return Ok(());
-        }
-    };
-
-    if !url.starts_with("http") {
-        check_msg(
-            msg.channel_id
-                .say(&ctx.http, "Must provide a valid URL")
-                .await,
-        );
-
-        return Ok(());
-    }
+#[aliases("p")]
+async fn play(ctx: &Context, msg: &Message, args: Args) -> CommandResult {
+    let song = args.rest().to_owned();
+    let is_url = song.starts_with("http");
 
     let guild = msg.guild(&ctx.cache).unwrap();
     let guild_id = guild.id;
@@ -121,78 +102,12 @@ async fn play(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult {
     if let Some(handler_lock) = manager.get(guild_id) {
         let mut handler = handler_lock.lock().await;
 
-        let source = match Restartable::ytdl(url, true).await {
-            Ok(source) => source,
-            Err(why) => {
-                error!("Err starting source: {:?}", why);
-
-                check_msg(msg.channel_id.say(&ctx.http, "Error sourcing ffmpeg").await);
-
-                return Ok(());
-            }
+        let resolved_source = match is_url {
+            true => Restartable::ytdl(song, true).await,
+            false => Restartable::ytdl_search(song, true).await,
         };
 
-        let current = handler.enqueue_source(source.into());
-
-        let embed = song_embed(current, handler.queue().len());
-        check_msg(
-            msg.channel_id
-                .send_message(&ctx.http, |m| {
-                    m.embed(|e| {
-                        e.0 = embed.0;
-                        e
-                    })
-                })
-                .await,
-        );
-    } else {
-        check_msg(
-            msg.channel_id
-                .say(&ctx.http, "Not in a voice channel to play in")
-                .await,
-        );
-    }
-
-    Ok(())
-}
-
-#[command]
-#[only_in(guilds)]
-#[aliases("se")]
-async fn search(ctx: &Context, msg: &Message, args: Args) -> CommandResult {
-    let song = args.rest();
-
-    let guild = msg.guild(&ctx.cache).unwrap();
-    let guild_id = guild.id;
-
-    let manager = songbird::get(ctx)
-        .await
-        .expect("Songbird Voice client placed in at initialisation.")
-        .clone();
-
-    let has_handler = manager.get(guild_id).is_some();
-    if !has_handler {
-        let channel_id = guild
-            .voice_states
-            .get(&msg.author.id)
-            .and_then(|voice_state| voice_state.channel_id);
-
-        let connect_to = match channel_id {
-            Some(channel) => channel,
-            None => {
-                check_msg(msg.reply(ctx, "Not in a voice channel").await);
-
-                return Ok(());
-            }
-        };
-
-        let _handler = manager.join(guild_id, connect_to).await;
-    }
-
-    if let Some(handler_lock) = manager.get(guild_id) {
-        let mut handler = handler_lock.lock().await;
-
-        let source = match Restartable::ytdl_search(song, true).await {
+        let source = match resolved_source {
             Ok(source) => source,
             Err(why) => {
                 error!("Err starting source: {:?}", why);
@@ -458,4 +373,3 @@ fn song_embed(current_track: TrackHandle, postion: usize) -> CreateEmbed {
         .to_owned();
     embed
 }
-

--- a/src/voice/cmds.rs
+++ b/src/voice/cmds.rs
@@ -1,3 +1,4 @@
+use crate::voice::disconnect_handler::ChannelDisconnect;
 use serenity::builder::CreateEmbed;
 use serenity::framework::standard::{macros::command, Args, CommandResult};
 use serenity::model::prelude::*;
@@ -100,6 +101,9 @@ async fn play(ctx: &Context, msg: &Message, args: Args) -> CommandResult {
     }
 
     if let Some(handler_lock) = manager.get(guild_id) {
+        let _dch = ChannelDisconnect::new(manager.clone(), ctx.http.clone(), guild_id)
+            .register_handler(&handler_lock)
+            .await;
         let mut handler = handler_lock.lock().await;
 
         let resolved_source = match is_url {

--- a/src/voice/disconnect_handler.rs
+++ b/src/voice/disconnect_handler.rs
@@ -1,0 +1,69 @@
+use once_cell::sync::Lazy;
+use serenity::async_trait;
+use serenity::http::Http;
+use serenity::model::prelude::*;
+use serenity::prelude::RwLock;
+use serenity::prelude::*;
+use songbird::{Call, Event, EventContext, EventHandler, Songbird};
+use std::{sync::Arc, time::Duration};
+use tracing::info;
+
+static HANDLER_ADDED: Lazy<RwLock<bool>> = Lazy::new(|| RwLock::new(false));
+const TIMEOUT_SECS: u64 = 420;
+
+#[derive(Clone)]
+pub struct ChannelDisconnect {
+    manager: Arc<Songbird>,
+    http: Arc<Http>,
+    guild_id: GuildId,
+}
+
+impl ChannelDisconnect {
+    pub fn new(manager: Arc<Songbird>, http: Arc<Http>, guild_id: GuildId) -> Self {
+        Self {
+            manager,
+            http,
+            guild_id,
+        }
+    }
+
+    pub async fn register_handler(&self, handler_lock: &Arc<Mutex<Call>>) {
+        if !*HANDLER_ADDED.read().await {
+            info!("Register handler for disconnect");
+            let mut ha = HANDLER_ADDED.write().await;
+            *ha = true;
+            let mut handler = handler_lock.lock().await;
+            handler.add_global_event(
+                Event::Periodic(Duration::from_secs(TIMEOUT_SECS), None),
+                self.clone(),
+            );
+        } else {
+            info!("No handler");
+        }
+    }
+
+    async fn disconnect(&self) {
+        let should_close = match self.manager.get(self.guild_id) {
+            None => false,
+            Some(handler_lock) => {
+                let handler = handler_lock.lock().await;
+                handler.queue().is_empty()
+            }
+        };
+
+        if should_close {
+            info!("Leaving voice channel.");
+            let _dc = self.manager.leave(self.guild_id).await;
+            info!("Left voice channel.");
+        }
+    }
+}
+
+#[async_trait]
+impl EventHandler for ChannelDisconnect {
+    async fn act(&self, _: &EventContext<'_>) -> Option<Event> {
+        info!("Checking if bot is active");
+        self.disconnect().await;
+        None
+    }
+}

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -1,0 +1,2 @@
+pub mod cmds;
+mod disconnect_handler;


### PR DESCRIPTION
- move `voice.rs` to its own separate module
- combine the play and search command into one, so it can now do both URL and normal song request.
- Add the disconnect handler that will periodically check if the bot currently has any songs in the queue, and if the queue is empty the bot will leave the voice channel.